### PR TITLE
Fixing a number of bugs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.1.8 (2021-03-02)
+------------------
+
+* No longer take over forms if they have a method and enctype browsers support.
+* Correctly serialize `application/x-www-form-urlencoded`. `FormData` doesn't
+  do it out of the box.
+
+
 0.1.7 (2021-02-06)
 ------------------
 

--- a/src/html-form-enhancer.ts
+++ b/src/html-form-enhancer.ts
@@ -15,11 +15,11 @@ export function autoEnhanceForms(doc: Document) {
   const forms = doc.getElementsByTagName('form');
   for(const form of forms) {
 
-    const method = form.getAttribute('method')?.toUpperCase();
+    const method = form.getAttribute('method')?.toUpperCase() || 'GET';
     const encType = form.getAttribute('enctype')?.toLowerCase();
 
     if (
-      ['POST','GET'].includes(method!) ||
+      !['POST','GET'].includes(method) ||
       encType === 'application/json'
     ) {
       enhanceForm(form);
@@ -50,7 +50,7 @@ async function processSubmit(elem: HTMLFormElement) {
   } else {
 
     if (!encType || encType === 'application/x-www-form-urlencoded') {
-      body = new FormData(elem);
+      body = new URLSearchParams(Object.fromEntries(new FormData(elem).entries()));
     } else if (encType === 'application/json' || encType.match(/^application\/(.*)\+json$/)) {
       body = JSON.stringify(serializeJsonForm(elem));
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "target": "es2017",
+        "target": "es2019",
 
         "strict": true,
         "noFallthroughCasesInSwitch": true,
@@ -19,10 +19,7 @@
         "lib": [
           "DOM",
           "DOM.Iterable",
-          "ES5",
-          "ES2015",
-          "ES2016",
-          "ES2017",
+          "ES2019",
           "ESNext.bigint"
         ],
         "declaration": true


### PR DESCRIPTION
* No longer take over forms if they have a method and enctype browsers support.
* Correctly serialize `application/x-www-form-urlencoded`. `FormData` doesn't
  do it out of the box.